### PR TITLE
add defaultReleaseType to be None in autorc file

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -9,6 +9,7 @@
   "repo": "physutils",
   "name": "Stefano Moia",
   "email": "s.moia@bcbl.eu",
+  "defaultReleaseType": "none",
   "labels": [
     {
       "name": "Majormod",


### PR DESCRIPTION
<!-- Write all of the issues that are linked to this pull request. -->
<!-- If this PR is enough to close them you can write something like "Closes #314 and closes #42" -->
<!-- If you just want to reference them without closing them, you can add something like "References #112" -->
Closes #

<!-- Add a short description of the PR content here-->

Problem with a plugin of auto:

Auto found a [commit](https://github.com/physiopy/physutils/pull/4/commits/f6b3d9f369b3a07f4c56454d9a189cb15bfd8da4) that looked like a conventional commit, and because the default for unknown labels is to "skip" release, it applied a "skip" mark and computed (correctly) the release as no increment:
https://github.com/physiopy/physutils/actions/runs/10497563830/job/29080679203#step:4:611


## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - Add`"defaultReleaseType": "none",` to the `.autorc` file

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [x] `bugfix` (+0.0.1)
- [ ] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [ ] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [ ] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [x] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [x] My code respects the adopted style, especially linting conventions.
- [x] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [x] Please, comment on my PR while it's a draft and give me feedback on the development!
